### PR TITLE
SWE-agent[bot] PR to fix: SyntaxError: invalid syntax

### DIFF
--- a/src/testpkg/missing_colon.py
+++ b/src/testpkg/missing_colon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-def division(a: float, b: float) -> float
+def division(a: float, b: float) -> float:
     return a/b
 
 


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/SWE-agent/SWE-agent/) to close [#1](https://github.com/psycholioa/test-repo/issues/1) (SyntaxError: invalid syntax).

Closes #1.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**🧑‍🚒 Response (0)**: 

**👀‍ Observation (0)**:
```
/psycholioa__test-repo/src/testpkg/long_file.py
/psycholioa__test-repo/src/testpkg/__init__.py
/psycholioa__test-repo/src/testpkg/missing_colon.py
/psycholioa__test-repo/src/testpkg/tribonacci.py
/psycholioa__test-repo/tests/test_tribonaccy.py
/psycholioa__test-repo/tests/existing_lint_error.py
/psycholioa__test-repo/tests/missing_colon.py
```

---

**🧑‍🚒 Response (1)**: 

**👀‍ Observation (1)**:
```
Here's the result of running `cat -n` on /psycholioa__test-repo/src/testpkg/missing_colon.py:
     1	#!/usr/bin/env python3
     2	
     3	
     4	def division(a: float, b: float) -> float
     5	    return a/b
     6	
     7	
     8	if __name__ == "__main__":
     9	    print(division(123, 15))
    10	
    11
```

---

**🧑‍🚒 Response (2)**: 

**👀‍ Observation (2)**:
```
Here's the result of running `cat -n` on /psycholioa__test-repo/tests/missing_colon.py:
     1	#!/usr/bin/env python3
     2	
     3	
     4	def division(a: float, b: float) -> float
     5	    return a/b
     6	
     7	
     8	if __name__ == "__main__":
     9	    print(division(123, 15))
    10	
    11
```

---

**🧑‍🚒 Response (3)**: 

**👀‍ Observation (3)**:
```
File "/psycholioa__test-repo/src/testpkg/missing_colon.py", line 4
    def division(a: float, b: float) -> float
                                             ^
SyntaxError: expected ':'
```

---

**🧑‍🚒 Response (4)**: 

**👀‍ Observation (4)**:
```
The file /psycholioa__test-repo/src/testpkg/missing_colon.py has been edited. Here's the result of running `cat -n` on a snippet of /psycholioa__test-repo/src/testpkg/missing_colon.py:
     1	#!/usr/bin/env python3
     2	
     3	
     4	def division(a: float, b: float) -> float:
     5	    return a/b
     6	
     7	
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (5)**: 

**👀‍ Observation (5)**:
```
8.2
```

---

**🧑‍🚒 Response (6)**: 
Here’s what I have done to address the issue as described in the PR description:

### Analysis & Error Reproduction

- The `missing_colon.py` file in `/src/testpkg/` had a function definition:
  ```python
  def division(a: float, b: float) -> float
      return a/b
  ```
  which was missing a colon (`:`) at the end of the `def` line, causing a `SyntaxError`.

- I ran the file and confirmed that the error reproduced as described.

### Fix

- I updated the function definition to:
  ```python
  def division(a: float, b: float) -> float:
      return a/b
  ```
- After making this change, I reran the script and confirmed that the error is resolved and the output is correct (`8.2` for `division(123, 15)`).

### Edge cases
- The function itself will still raise an error if division by zero is attempted (e.g., `division(23, 0)`), which is the native Python behavior (`ZeroDivisionError`). The original PR description does not request handling for such cases, so I preserved the logic.

### Summary

- The `SyntaxError` due to a missing colon has been fixed.
- The function is now properly defined and runs as expected.

Let me know if you want me to also add error-handling for division by zero or perform any further changes! I will now submit the results.
**👀‍ Observation (6)**:
```
Thank you for your work on this issue. Please carefully follow the steps below to help review your changes.

1. If you made any changes to your code after running the reproduction script, please run the reproduction script again.
  If the reproduction script is failing, please revisit your changes and make sure they are correct.
  If you have already removed your reproduction script, please ignore this step.
2. Remove your reproduction script (if you haven't done so already).
3. If you have modified any TEST files, please revert them to the state they had before you started fixing the issue.
  You can do this with `git checkout -- /path/to/test/file.py`. Use below <diff> to find the files you need to revert.
4. Run the submit command again to confirm.

Here is a list of all of your changes:

<diff>
diff --git a/src/testpkg/missing_colon.py b/src/testpkg/missing_colon.py
index 20edef5..5857437 100755
--- a/src/testpkg/missing_colon.py
+++ b/src/testpkg/missing_colon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-def division(a: float, b: float) -> float
+def division(a: float, b: float) -> float:
     return a/b
 
 

</diff>
```

---

**🧑‍🚒 Response (7)**: 
The relevant fix has been made only to the source file (`src/testpkg/missing_colon.py`). No changes were made to any test files or extraneous files, and the repository is now functioning as specified in the PR description. The syntax error is resolved.

If you need additional features such as error handling for division by zero, let me know! Otherwise, the repository is now ready and you can proceed with your workflow.
**👀‍ Observation (7)**:
```

```

---

**🧑‍🚒 Response (8)**: 

**👀‍ Observation (8)**:
```
diff --git a/src/testpkg/missing_colon.py b/src/testpkg/missing_colon.py
index 20edef5..5857437 100755
--- a/src/testpkg/missing_colon.py
+++ b/src/testpkg/missing_colon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 
-def division(a: float, b: float) -> float
+def division(a: float, b: float) -> float:
     return a/b
```
</details>